### PR TITLE
Upgrade php-cs-fixer from v2.11.1 to v2.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG COMPOSER_IMAGE="composer:1.6.4"
 ARG BASE_IMAGE="php:7.2-alpine"
 ARG PACKAGIST_NAME="friendsofphp/php-cs-fixer"
 ARG PHPQA_NAME="php-cs-fixer"
-ARG VERSION="2.11.1"
+ARG VERSION="2.11.2"
 
 # Download with Composer - https://getcomposer.org/
 


### PR DESCRIPTION
This change upgrades php-cs-fixer from v2.11.1 to v2.11.2.

Test results in my local environment:

<img width="964" alt="2 11 2" src="https://user-images.githubusercontent.com/855338/41578039-3a0765b2-73cb-11e8-8405-03ed568e96b3.png">

Also I have sent two PRs #2 (php-cs-fixer v2.12.0) and #3 (php-cs-fixer v2.12.1). I would like you to merge this PR before you merge the two PRs, so that commit log will be clean; php-cs-version will be ordered from older version to newer version.

- Next PR: #2