### PR TITLE
Upgrade php-cs-fixer from v2.11.2 to v2.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG COMPOSER_IMAGE="composer:1.6.4"
 ARG BASE_IMAGE="php:7.2-alpine"
 ARG PACKAGIST_NAME="friendsofphp/php-cs-fixer"
 ARG PHPQA_NAME="php-cs-fixer"
-ARG VERSION="2.11.2"
+ARG VERSION="2.12.0"
 
 # Download with Composer - https://getcomposer.org/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG COMPOSER_IMAGE="composer:1.6.4"
 ARG BASE_IMAGE="php:7.2-alpine"
 ARG PACKAGIST_NAME="friendsofphp/php-cs-fixer"
 ARG PHPQA_NAME="php-cs-fixer"
-ARG VERSION="2.11.1"
+ARG VERSION="2.11.2"
 
 # Download with Composer - https://getcomposer.org/
 


### PR DESCRIPTION
This change upgrades php-cs-fixer from v2.11.2 to v2.12.0. 

I would like you to merge #1 before you merge this, so that the commit log will be ordered from older version to newer version.

Test result in my local environment:

<img width="961" alt="2 12 0" src="https://user-images.githubusercontent.com/855338/41578327-ac88e880-73cc-11e8-8477-f6e560ef910c.png">

- Previous PR: #1 
- Next PR: #3 
