### PR TITLE
Upgrade php-cs-fixer from v2.12.0 to v2.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG COMPOSER_IMAGE="composer:1.6.4"
 ARG BASE_IMAGE="php:7.2-alpine"
 ARG PACKAGIST_NAME="friendsofphp/php-cs-fixer"
 ARG PHPQA_NAME="php-cs-fixer"
-ARG VERSION="2.12.0"
+ARG VERSION="2.12.1"
 
 # Download with Composer - https://getcomposer.org/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG COMPOSER_IMAGE="composer:1.6.4"
 ARG BASE_IMAGE="php:7.2-alpine"
 ARG PACKAGIST_NAME="friendsofphp/php-cs-fixer"
 ARG PHPQA_NAME="php-cs-fixer"
-ARG VERSION="2.11.2"
+ARG VERSION="2.12.0"
 
 # Download with Composer - https://getcomposer.org/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG COMPOSER_IMAGE="composer:1.6.4"
 ARG BASE_IMAGE="php:7.2-alpine"
 ARG PACKAGIST_NAME="friendsofphp/php-cs-fixer"
 ARG PHPQA_NAME="php-cs-fixer"
-ARG VERSION="2.11.1"
+ARG VERSION="2.11.2"
 
 # Download with Composer - https://getcomposer.org/
 


### PR DESCRIPTION
This change upgrades php-cs-fixer from v2.12.0 to v2.12.1

I would like you to merge #2 before you merge this, so that the commit log will be ordered from older version to newer version.

Test result in my local environment:

<img width="967" alt="2 12 1" src="https://user-images.githubusercontent.com/855338/41578528-c2da0b5e-73cd-11e8-84db-0e2a2098e0e1.png">

- Previous PR: #2 
- Next PR: None